### PR TITLE
Fix dead lock issue caused by blocking informer and refine obs-gap server implementation

### DIFF
--- a/instrumentation/instr.go
+++ b/instrumentation/instr.go
@@ -18,20 +18,15 @@ func instrumentControllerForTimeTravel(controller_runtime_filepath string) {
 	instrumentClientGoForAll(clientGoFile, clientGoFile, "TimeTravel", false)
 }
 
-/* API interface:
-1. notify that we get some event into localcache (just recv event from API server) (cannot be runtime, but it is bind with watch(?))
-2. block the reconcile (in runtime)
-*/
 func instrumentControllerForObsGap(controller_runtime_filepath string, client_go_filepath string) {
-	// client.go: before apply to cache
-	controllerGoFile := path.Join(controller_runtime_filepath, "pkg", "internal", "controller", "controller.go")
-	fmt.Printf("instrumenting %s\n", controllerGoFile)
-	instrumentControllerGoForObsGap(controllerGoFile, controllerGoFile)
-
 	sharedInformerGoFile := path.Join(client_go_filepath, "tools", "cache", "shared_informer.go")
 	fmt.Printf("instrumenting %s\n", sharedInformerGoFile)
 	preprocess(sharedInformerGoFile)
 	instrumentSharedInformerGoForObsGap(sharedInformerGoFile, sharedInformerGoFile)
+
+	informerCacheGoFile := path.Join(controller_runtime_filepath, "pkg", "cache", "informer_cache.go")
+	fmt.Printf("instrumenting %s\n", informerCacheGoFile)
+	instrumentInformerCacheGoForObsGap(informerCacheGoFile, informerCacheGoFile)
 
 	clientGoFile := path.Join(controller_runtime_filepath, "pkg", "client", "client.go")
 	fmt.Printf("instrumenting %s\n", clientGoFile)

--- a/instrumentation/obs_gap_instr.go
+++ b/instrumentation/obs_gap_instr.go
@@ -100,33 +100,3 @@ func instrumentInformerCacheRead(f *dst.File, etype, mode string) {
 		panic(fmt.Errorf("Cannot find function %s", etype))
 	}
 }
-
-// func instrumentControllerGoForObsGap(ifilepath, ofilepath string) {
-// 	f := parseSourceFile(ifilepath, "controller")
-// 	_, funcDecl := findFuncDecl(f, "reconcileHandler")
-// 	if funcDecl != nil {
-// 		index := 0
-// 		beforeReconcileInstrumentation := &dst.ExprStmt{
-// 			X: &dst.CallExpr{
-// 				Fun:  &dst.Ident{Name: "NotifyObsGapBeforeReconcile", Path: "sieve.client"},
-// 				Args: []dst.Expr{&dst.Ident{Name: "c.Name"}},
-// 			},
-// 		}
-// 		beforeReconcileInstrumentation.Decs.End.Append("//sieve")
-// 		insertStmt(&funcDecl.Body.List, index, beforeReconcileInstrumentation)
-
-// 		index += 1
-// 		afterReconcileInstrumentation := &dst.DeferStmt{
-// 			Call: &dst.CallExpr{
-// 				Fun:  &dst.Ident{Name: "NotifyObsGapAfterReconcile", Path: "sieve.client"},
-// 				Args: []dst.Expr{&dst.Ident{Name: "c.Name"}},
-// 			},
-// 		}
-// 		afterReconcileInstrumentation.Decs.End.Append("//sieve")
-// 		insertStmt(&funcDecl.Body.List, index, afterReconcileInstrumentation)
-// 	} else {
-// 		panic(fmt.Errorf("Cannot find function reconcileHandler"))
-// 	}
-
-// 	writeInstrumentedFile(ofilepath, "controller", f)
-// }

--- a/instrumentation/obs_gap_instr.go
+++ b/instrumentation/obs_gap_instr.go
@@ -33,39 +33,100 @@ func instrumentSharedInformerGoForObsGap(ifilepath, ofilepath string) {
 				break
 			}
 		}
+		writeInstrumentedFile(ofilepath, "cache", f)
 	} else {
 		panic(fmt.Errorf("Cannot find function HandleDeltas"))
 	}
+}
+
+func instrumentInformerCacheGoForObsGap(ifilepath, ofilepath string) {
+	f := parseSourceFile(ifilepath, "cache")
+
+	instrumentInformerCacheRead(f, "Get", "ObsGap")
+	instrumentInformerCacheRead(f, "List", "ObsGap")
 
 	writeInstrumentedFile(ofilepath, "cache", f)
 }
 
-func instrumentControllerGoForObsGap(ifilepath, ofilepath string) {
-	f := parseSourceFile(ifilepath, "controller")
-	_, funcDecl := findFuncDecl(f, "reconcileHandler")
+func instrumentInformerCacheRead(f *dst.File, etype, mode string) {
+	funNameBefore := "Notify" + mode + "BeforeInformerCache" + etype
+	funNameAfter := "Notify" + mode + "AfterInformerCache" + etype
+	_, funcDecl := findFuncDecl(f, etype)
 	if funcDecl != nil {
-		index := 0
-		beforeReconcileInstrumentation := &dst.ExprStmt{
-			X: &dst.CallExpr{
-				Fun:  &dst.Ident{Name: "NotifyObsGapBeforeReconcile", Path: "sieve.client"},
-				Args: []dst.Expr{&dst.Ident{Name: "c.Name"}},
-			},
-		}
-		beforeReconcileInstrumentation.Decs.End.Append("//sieve")
-		insertStmt(&funcDecl.Body.List, index, beforeReconcileInstrumentation)
+		if _, ok := funcDecl.Body.List[len(funcDecl.Body.List)-1].(*dst.ReturnStmt); ok {
+			if etype == "Get" {
+				beforeGetInstrumentation := &dst.ExprStmt{
+					X: &dst.CallExpr{
+						Fun:  &dst.Ident{Name: funNameBefore, Path: "sieve.client"},
+						Args: []dst.Expr{&dst.Ident{Name: "\"Get\""}, &dst.Ident{Name: "key"}, &dst.Ident{Name: "out"}},
+					},
+				}
+				beforeGetInstrumentation.Decs.End.Append("//sieve")
+				insertStmt(&funcDecl.Body.List, len(funcDecl.Body.List)-1, beforeGetInstrumentation)
 
-		index += 1
-		afterReconcileInstrumentation := &dst.DeferStmt{
-			Call: &dst.CallExpr{
-				Fun:  &dst.Ident{Name: "NotifyObsGapAfterReconcile", Path: "sieve.client"},
-				Args: []dst.Expr{&dst.Ident{Name: "c.Name"}},
-			},
+				afterGetInstrumentation := &dst.DeferStmt{
+					Call: &dst.CallExpr{
+						Fun:  &dst.Ident{Name: funNameAfter, Path: "sieve.client"},
+						Args: []dst.Expr{&dst.Ident{Name: "\"Get\""}, &dst.Ident{Name: "key"}, &dst.Ident{Name: "out"}},
+					},
+				}
+				afterGetInstrumentation.Decs.End.Append("//sieve")
+				insertStmt(&funcDecl.Body.List, len(funcDecl.Body.List)-1, afterGetInstrumentation)
+			} else if etype == "List" {
+				beforeListInstrumentation := &dst.ExprStmt{
+					X: &dst.CallExpr{
+						Fun:  &dst.Ident{Name: funNameBefore, Path: "sieve.client"},
+						Args: []dst.Expr{&dst.Ident{Name: "\"List\""}, &dst.Ident{Name: "out"}},
+					},
+				}
+				beforeListInstrumentation.Decs.End.Append("//sieve")
+				insertStmt(&funcDecl.Body.List, len(funcDecl.Body.List)-1, beforeListInstrumentation)
+
+				afterListInstrumentation := &dst.DeferStmt{
+					Call: &dst.CallExpr{
+						Fun:  &dst.Ident{Name: funNameAfter, Path: "sieve.client"},
+						Args: []dst.Expr{&dst.Ident{Name: "\"List\""}, &dst.Ident{Name: "out"}},
+					},
+				}
+				afterListInstrumentation.Decs.End.Append("//sieve")
+				insertStmt(&funcDecl.Body.List, len(funcDecl.Body.List)-1, afterListInstrumentation)
+			} else {
+				panic(fmt.Errorf("Wrong type %s for operator read", etype))
+			}
+		} else {
+			panic(fmt.Errorf("Last stmt of %s is not return", etype))
 		}
-		afterReconcileInstrumentation.Decs.End.Append("//sieve")
-		insertStmt(&funcDecl.Body.List, index, afterReconcileInstrumentation)
 	} else {
-		panic(fmt.Errorf("Cannot find function reconcileHandler"))
+		panic(fmt.Errorf("Cannot find function %s", etype))
 	}
-
-	writeInstrumentedFile(ofilepath, "controller", f)
 }
+
+// func instrumentControllerGoForObsGap(ifilepath, ofilepath string) {
+// 	f := parseSourceFile(ifilepath, "controller")
+// 	_, funcDecl := findFuncDecl(f, "reconcileHandler")
+// 	if funcDecl != nil {
+// 		index := 0
+// 		beforeReconcileInstrumentation := &dst.ExprStmt{
+// 			X: &dst.CallExpr{
+// 				Fun:  &dst.Ident{Name: "NotifyObsGapBeforeReconcile", Path: "sieve.client"},
+// 				Args: []dst.Expr{&dst.Ident{Name: "c.Name"}},
+// 			},
+// 		}
+// 		beforeReconcileInstrumentation.Decs.End.Append("//sieve")
+// 		insertStmt(&funcDecl.Body.List, index, beforeReconcileInstrumentation)
+
+// 		index += 1
+// 		afterReconcileInstrumentation := &dst.DeferStmt{
+// 			Call: &dst.CallExpr{
+// 				Fun:  &dst.Ident{Name: "NotifyObsGapAfterReconcile", Path: "sieve.client"},
+// 				Args: []dst.Expr{&dst.Ident{Name: "c.Name"}},
+// 			},
+// 		}
+// 		afterReconcileInstrumentation.Decs.End.Append("//sieve")
+// 		insertStmt(&funcDecl.Body.List, index, afterReconcileInstrumentation)
+// 	} else {
+// 		panic(fmt.Errorf("Cannot find function reconcileHandler"))
+// 	}
+
+// 	writeInstrumentedFile(ofilepath, "controller", f)
+// }

--- a/sieve-client/obs_gap_client.go
+++ b/sieve-client/obs_gap_client.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func NotifyObsGapBeforeIndexerWrite(operationType string, object interface{}) {
@@ -87,55 +88,99 @@ func NotifyObsGapAfterIndexerWrite(operationType string, object interface{}) {
 	client.Close()
 }
 
-func NotifyObsGapBeforeReconcile(controllerName string) {
+func NotifyObsGapBeforeInformerCacheGet(readType string, namespacedName types.NamespacedName, object interface{}) {
 	if err := loadSieveConfig(); err != nil {
 		return
 	}
 	if !checkStage(TEST) || !checkMode(OBS_GAP) {
 		return
 	}
-	log.Printf("[sieve][NotifyObsGapBeforeReconcile]\n")
+	log.Printf("[sieve][NotifyObsGapBeforeInformerCacheGet]\n")
 	client, err := newClient()
 	if err != nil {
 		printError(err, SIEVE_CONN_ERR)
 		return
 	}
-	request := &NotifyObsGapBeforeReconcileRequest{
-		ControllerName: controllerName,
-	}
+	request := &NotifyObsGapBeforeInformerCacheReadRequest{}
 	var response Response
-	err = client.Call("ObsGapListener.NotifyObsGapBeforeReconcile", request, &response)
+	err = client.Call("ObsGapListener.NotifyObsGapBeforeInformerCacheRead", request, &response)
 	if err != nil {
 		printError(err, SIEVE_REPLY_ERR)
 		return
 	}
-	checkResponse(response, "NotifyObsGapBeforeReconcile")
+	checkResponse(response, "NotifyObsGapBeforeInformerCacheGet")
 	client.Close()
 }
 
-func NotifyObsGapAfterReconcile(controllerName string) {
+func NotifyObsGapAfterInformerCacheGet(readType string, namespacedName types.NamespacedName, object interface{}) {
 	if err := loadSieveConfig(); err != nil {
 		return
 	}
 	if !checkStage(TEST) || !checkMode(OBS_GAP) {
 		return
 	}
-	log.Printf("[sieve][NotifyObsGapAfterReconcile]\n")
+	log.Printf("[sieve][NotifyObsGapAfterInformerCacheGet]\n")
 	client, err := newClient()
 	if err != nil {
 		printError(err, SIEVE_CONN_ERR)
 		return
 	}
-	request := &NotifyObsGapAfterReconcileRequest{
-		ControllerName: controllerName,
-	}
+	request := &NotifyObsGapAfterInformerCacheReadRequest{}
 	var response Response
-	err = client.Call("ObsGapListener.NotifyObsGapAfterReconcile", request, &response)
+	err = client.Call("ObsGapListener.NotifyObsGapAfterInformerCacheRead", request, &response)
 	if err != nil {
 		printError(err, SIEVE_REPLY_ERR)
 		return
 	}
-	checkResponse(response, "NotifyObsGapAfterReconcile")
+	checkResponse(response, "NotifyObsGapAfterInformerCacheGet")
+	client.Close()
+}
+
+func NotifyObsGapBeforeInformerCacheList(readType string, object interface{}) {
+	if err := loadSieveConfig(); err != nil {
+		return
+	}
+	if !checkStage(TEST) || !checkMode(OBS_GAP) {
+		return
+	}
+	log.Printf("[sieve][NotifyObsGapBeforeInformerCacheList]\n")
+	client, err := newClient()
+	if err != nil {
+		printError(err, SIEVE_CONN_ERR)
+		return
+	}
+	request := &NotifyObsGapBeforeInformerCacheReadRequest{}
+	var response Response
+	err = client.Call("ObsGapListener.NotifyObsGapBeforeInformerCacheRead", request, &response)
+	if err != nil {
+		printError(err, SIEVE_REPLY_ERR)
+		return
+	}
+	checkResponse(response, "NotifyObsGapBeforeInformerCacheList")
+	client.Close()
+}
+
+func NotifyObsGapAfterInformerCacheList(readType string, object interface{}) {
+	if err := loadSieveConfig(); err != nil {
+		return
+	}
+	if !checkStage(TEST) || !checkMode(OBS_GAP) {
+		return
+	}
+	log.Printf("[sieve][NotifyObsGapAfterInformerCacheList]\n")
+	client, err := newClient()
+	if err != nil {
+		printError(err, SIEVE_CONN_ERR)
+		return
+	}
+	request := &NotifyObsGapAfterInformerCacheReadRequest{}
+	var response Response
+	err = client.Call("ObsGapListener.NotifyObsGapAfterInformerCacheRead", request, &response)
+	if err != nil {
+		printError(err, SIEVE_REPLY_ERR)
+		return
+	}
+	checkResponse(response, "NotifyObsGapAfterInformerCacheList")
 	client.Close()
 }
 

--- a/sieve-client/obs_gap_client.go
+++ b/sieve-client/obs_gap_client.go
@@ -95,13 +95,25 @@ func NotifyObsGapBeforeInformerCacheGet(readType string, namespacedName types.Na
 	if !checkStage(TEST) || !checkMode(OBS_GAP) {
 		return
 	}
-	log.Printf("[sieve][NotifyObsGapBeforeInformerCacheGet]\n")
+	rType := regularizeType(object)
+	if rType != config["ce-rtype"].(string) {
+		return
+	}
+	if namespacedName.Name != config["ce-name"].(string) || namespacedName.Namespace != config["ce-namespace"].(string) {
+		return
+	}
+	log.Printf("[sieve][NotifyObsGapBeforeInformerCacheGet] type: %s, ns: %s name: %s", rType, namespacedName.Namespace, namespacedName.Name)
 	client, err := newClient()
 	if err != nil {
 		printError(err, SIEVE_CONN_ERR)
 		return
 	}
-	request := &NotifyObsGapBeforeInformerCacheReadRequest{}
+	request := &NotifyObsGapBeforeInformerCacheReadRequest{
+		OperationType: readType,
+		ResourceType:  rType,
+		Namespace:     namespacedName.Namespace,
+		Name:          namespacedName.Name,
+	}
 	var response Response
 	err = client.Call("ObsGapListener.NotifyObsGapBeforeInformerCacheRead", request, &response)
 	if err != nil {
@@ -119,13 +131,25 @@ func NotifyObsGapAfterInformerCacheGet(readType string, namespacedName types.Nam
 	if !checkStage(TEST) || !checkMode(OBS_GAP) {
 		return
 	}
-	log.Printf("[sieve][NotifyObsGapAfterInformerCacheGet]\n")
+	rType := regularizeType(object)
+	if rType != config["ce-rtype"].(string) {
+		return
+	}
+	if namespacedName.Name != config["ce-name"].(string) || namespacedName.Namespace != config["ce-namespace"].(string) {
+		return
+	}
+	log.Printf("[sieve][NotifyObsGapAfterInformerCacheGet] type: %s, ns: %s name: %s", rType, namespacedName.Namespace, namespacedName.Name)
 	client, err := newClient()
 	if err != nil {
 		printError(err, SIEVE_CONN_ERR)
 		return
 	}
-	request := &NotifyObsGapAfterInformerCacheReadRequest{}
+	request := &NotifyObsGapAfterInformerCacheReadRequest{
+		OperationType: readType,
+		ResourceType:  rType,
+		Namespace:     namespacedName.Namespace,
+		Name:          namespacedName.Name,
+	}
 	var response Response
 	err = client.Call("ObsGapListener.NotifyObsGapAfterInformerCacheRead", request, &response)
 	if err != nil {
@@ -143,13 +167,20 @@ func NotifyObsGapBeforeInformerCacheList(readType string, object interface{}) {
 	if !checkStage(TEST) || !checkMode(OBS_GAP) {
 		return
 	}
-	log.Printf("[sieve][NotifyObsGapBeforeInformerCacheList]\n")
+	rType := regularizeType(object)
+	if rType != config["ce-rtype"].(string)+"list" {
+		return
+	}
+	log.Printf("[sieve][NotifyObsGapBeforeInformerCacheList] type: %s", rType)
 	client, err := newClient()
 	if err != nil {
 		printError(err, SIEVE_CONN_ERR)
 		return
 	}
-	request := &NotifyObsGapBeforeInformerCacheReadRequest{}
+	request := &NotifyObsGapBeforeInformerCacheReadRequest{
+		OperationType: readType,
+		ResourceType:  rType,
+	}
 	var response Response
 	err = client.Call("ObsGapListener.NotifyObsGapBeforeInformerCacheRead", request, &response)
 	if err != nil {
@@ -167,13 +198,20 @@ func NotifyObsGapAfterInformerCacheList(readType string, object interface{}) {
 	if !checkStage(TEST) || !checkMode(OBS_GAP) {
 		return
 	}
-	log.Printf("[sieve][NotifyObsGapAfterInformerCacheList]\n")
+	rType := regularizeType(object)
+	if rType != config["ce-rtype"].(string)+"list" {
+		return
+	}
+	log.Printf("[sieve][NotifyObsGapAfterInformerCacheList] type: %s", rType)
 	client, err := newClient()
 	if err != nil {
 		printError(err, SIEVE_CONN_ERR)
 		return
 	}
-	request := &NotifyObsGapAfterInformerCacheReadRequest{}
+	request := &NotifyObsGapAfterInformerCacheReadRequest{
+		OperationType: readType,
+		ResourceType:  rType,
+	}
 	var response Response
 	err = client.Call("ObsGapListener.NotifyObsGapAfterInformerCacheRead", request, &response)
 	if err != nil {

--- a/sieve-client/types.go
+++ b/sieve-client/types.go
@@ -53,9 +53,17 @@ type NotifyObsGapBeforeIndexerWriteRequest struct {
 }
 
 type NotifyObsGapBeforeInformerCacheReadRequest struct {
+	OperationType string
+	ResourceType  string
+	Name          string
+	Namespace     string
 }
 
 type NotifyObsGapAfterInformerCacheReadRequest struct {
+	OperationType string
+	ResourceType  string
+	Name          string
+	Namespace     string
 }
 
 type NotifyObsGapAfterIndexerWriteRequest struct {

--- a/sieve-client/types.go
+++ b/sieve-client/types.go
@@ -52,12 +52,10 @@ type NotifyObsGapBeforeIndexerWriteRequest struct {
 	ResourceType  string
 }
 
-type NotifyObsGapBeforeReconcileRequest struct {
-	ControllerName string
+type NotifyObsGapBeforeInformerCacheReadRequest struct {
 }
 
-type NotifyObsGapAfterReconcileRequest struct {
-	ControllerName string
+type NotifyObsGapAfterInformerCacheReadRequest struct {
 }
 
 type NotifyObsGapAfterIndexerWriteRequest struct {

--- a/sieve-server/obs_gap_server.go
+++ b/sieve-server/obs_gap_server.go
@@ -101,7 +101,7 @@ func (s *obsGapServer) NotifyObsGapAfterIndexerWrite(request *sieve.NotifyObsGap
 		log.Fatalf("encounter unexpected object: %s %s", request.ResourceType, request.Object)
 	}
 	// If we are inside pausing, then we check for target event which can cancel the crucial one
-	log.Println("NotifyObsGapAfterIndexerWrite", s.pausingReconcile, "pausedReconcileCnt")
+	log.Println("NotifyObsGapAfterIndexerWrite", s.pausingReconcile)
 	if s.pausingReconcile {
 		if request.OperationType == "Deleted" || conflictingEventAsMap(s.diffCurEvent, currentEvent) {
 			// TODO: we should also consider the corner case where s.diffCurEvent == {}
@@ -117,6 +117,15 @@ func (s *obsGapServer) NotifyObsGapAfterIndexerWrite(request *sieve.NotifyObsGap
 }
 
 func (s *obsGapServer) NotifyObsGapBeforeInformerCacheRead(request *sieve.NotifyObsGapBeforeInformerCacheReadRequest, response *sieve.Response) error {
+	if request.OperationType == "Get" {
+		if !(request.ResourceType == s.ceRtype && request.Name == s.ceName && request.Namespace == s.ceNamespace) {
+			log.Fatalf("encounter unexpected object: %s %s %s", request.ResourceType, request.Namespace, request.Name)
+		}
+	} else {
+		if !(request.ResourceType == s.ceRtype+"list") {
+			log.Fatalf("encounter unexpected object: %s", request.ResourceType)
+		}
+	}
 	log.Println("NotifyObsGapBeforeInformerCacheRead[0/1]", s.pausingReconcile)
 	s.reconcilingMutex.Lock()
 	log.Println("NotifyObsGapBeforeInformerCacheRead[1/1]", s.pausingReconcile)
@@ -125,6 +134,15 @@ func (s *obsGapServer) NotifyObsGapBeforeInformerCacheRead(request *sieve.Notify
 }
 
 func (s *obsGapServer) NotifyObsGapAfterInformerCacheRead(request *sieve.NotifyObsGapAfterInformerCacheReadRequest, response *sieve.Response) error {
+	if request.OperationType == "Get" {
+		if !(request.ResourceType == s.ceRtype && request.Name == s.ceName && request.Namespace == s.ceNamespace) {
+			log.Fatalf("encounter unexpected object: %s %s %s", request.ResourceType, request.Namespace, request.Name)
+		}
+	} else {
+		if !(request.ResourceType == s.ceRtype+"list") {
+			log.Fatalf("encounter unexpected object: %s", request.ResourceType)
+		}
+	}
 	log.Println("NotifyObsGapAfterInformerCacheRead")
 	s.reconcilingMutex.Unlock()
 	*response = sieve.Response{Ok: true}

--- a/sieve-server/obs_gap_server.go
+++ b/sieve-server/obs_gap_server.go
@@ -50,12 +50,12 @@ func (l *ObsGapListener) NotifyObsGapAfterIndexerWrite(request *sieve.NotifyObsG
 	return l.Server.NotifyObsGapAfterIndexerWrite(request, response)
 }
 
-func (l *ObsGapListener) NotifyObsGapBeforeReconcile(request *sieve.NotifyObsGapBeforeReconcileRequest, response *sieve.Response) error {
-	return l.Server.NotifyObsGapBeforeReconcile(request, response)
+func (l *ObsGapListener) NotifyObsGapBeforeInformerCacheRead(request *sieve.NotifyObsGapBeforeInformerCacheReadRequest, response *sieve.Response) error {
+	return l.Server.NotifyObsGapBeforeInformerCacheRead(request, response)
 }
 
-func (l *ObsGapListener) NotifyObsGapAfterReconcile(request *sieve.NotifyObsGapAfterReconcileRequest, response *sieve.Response) error {
-	return l.Server.NotifyObsGapAfterReconcile(request, response)
+func (l *ObsGapListener) NotifyObsGapAfterInformerCacheRead(request *sieve.NotifyObsGapAfterInformerCacheReadRequest, response *sieve.Response) error {
+	return l.Server.NotifyObsGapAfterInformerCacheRead(request, response)
 }
 
 func (l *ObsGapListener) NotifyObsGapAfterSideEffects(request *sieve.NotifyObsGapAfterSideEffectsRequest, response *sieve.Response) error {
@@ -143,26 +143,24 @@ func (s *obsGapServer) NotifyObsGapAfterIndexerWrite(request *sieve.NotifyObsGap
 	return nil
 }
 
-func (s *obsGapServer) NotifyObsGapBeforeReconcile(request *sieve.NotifyObsGapBeforeReconcileRequest, response *sieve.Response) error {
+func (s *obsGapServer) NotifyObsGapBeforeInformerCacheRead(request *sieve.NotifyObsGapBeforeInformerCacheReadRequest, response *sieve.Response) error {
 	s.reconcilingMutex.Lock()
-	recID := request.ControllerName
 	s.mutex.Lock()
-	log.Println("NotifyObsGapBeforeReconcile[0/1]", recID, s.pausingReconcile)
+	log.Println("NotifyObsGapBeforeInformerCacheRead[0/1]", s.pausingReconcile)
 	if s.pausingReconcile {
 		atomic.AddInt32(&s.pausedReconcileCnt, 1)
 	}
 	for s.pausingReconcile {
 		s.cond.Wait()
 	}
-	log.Println("NotifyObsGapBeforeReconcile[1/1]", recID, s.pausingReconcile)
+	log.Println("NotifyObsGapBeforeInformerCacheRead[1/1]", s.pausingReconcile)
 	s.mutex.Unlock()
 	*response = sieve.Response{Ok: true}
 	return nil
 }
 
-func (s *obsGapServer) NotifyObsGapAfterReconcile(request *sieve.NotifyObsGapAfterReconcileRequest, response *sieve.Response) error {
-	recID := request.ControllerName
-	log.Println("NotifyObsGapAfterReconcile", recID)
+func (s *obsGapServer) NotifyObsGapAfterInformerCacheRead(request *sieve.NotifyObsGapAfterInformerCacheReadRequest, response *sieve.Response) error {
+	log.Println("NotifyObsGapAfterInformerCacheRead")
 	s.reconcilingMutex.Unlock()
 	*response = sieve.Response{Ok: true}
 	return nil

--- a/sieve-server/obs_gap_server.go
+++ b/sieve-server/obs_gap_server.go
@@ -116,6 +116,9 @@ func (s *obsGapServer) NotifyObsGapAfterIndexerWrite(request *sieve.NotifyObsGap
 	return nil
 }
 
+// Note that we are blocking the reconciler before reading the resource involved in the crucial event
+// If the reconciler has already read some other resource in one reconcile,
+// after removing the block there could be some inconsistency between the previously read data and the crucial event
 func (s *obsGapServer) NotifyObsGapBeforeInformerCacheRead(request *sieve.NotifyObsGapBeforeInformerCacheReadRequest, response *sieve.Response) error {
 	if request.OperationType == "Get" {
 		if !(request.ResourceType == s.ceRtype && request.Name == s.ceName && request.Namespace == s.ceNamespace) {


### PR DESCRIPTION
Instead of blocking the whole reconcile, we should block after the reconciler calling `informer.HasSynced` and before reading the reconciler. This will avoid the deadlock issue as the reconciler will not wait for any lock when the informer is also blocked.
Besides we use only one lock to coordinate between the informer and the reconciler:
- everytime before reading the object, the reconciler needs to grab the lock. After reading the object, the lock will be released
- when seeing the crucial event (to make the reconciler miss), the informer will try to grab the same lock. This ensures that the crucial event is only written to the indexer while no one is reading the indexer. And after that since the lock is held by the informer the reconciler will not be able to see the crucial event
- when a following cancelling event comes the informer will release the lock. After that, the reconciler can continue w/o seeing the crucial event.