### PR TITLE
Fix PermissionError hit while reproducing rabbitmq-cluster-operator-782

### DIFF
--- a/sieve.py
+++ b/sieve.py
@@ -547,7 +547,10 @@ def run_workload(
         )
     )
     # Stop streaming controller log.
-    os.killpg(streaming.pid, signal.SIGTERM)
+    try:
+        os.killpg(streaming.pid, signal.SIGTERM)
+    except Exception as e:
+        print("Unable to kill controller log streaming process: ", e)
     streamed_log_file.close()
     # Stop streaming apiserver log.
     os.killpg(streaming_api_server.pid, signal.SIGTERM)


### PR DESCRIPTION
While trying to reproduce intermediate-state bug 1: rabbitmq-cluster-operator-782 with Sieve on my Mac machine, I hit the below error:
  File "/Users/jshajigeorge/work/sieve/sieve.py", line 550, in run_workload
    os.killpg(streaming.pid, signal.SIGTERM)
PermissionError: [Errno 1] Operation not permitted

This is because Sieve is trying to kill the controller log streaming process which is already in a Zombie process. This is not permitted in Mac - zombie processes are reaped by its parent when the parent dies.

This change fixes this issue by ignoring the exception raised when this happens and adds a log statement to report this.

fixes #115