### PR TITLE
Catch unsupported build mode passed to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -660,6 +660,10 @@ if __name__ == "__main__":
     ]:
         parser.error("invalid build mode option: {}".format(options.mode))
 
+    if options.mode == sieve_modes.ALL and options.build_only:
+        parser.error("Building controller docker image for ALL mode not"
+                     " supported. Supported modes:  vanilla, learn and test")
+
     if options.controller_config_dir is None:
         setup_kubernetes_wrapper(
             options.version,


### PR DESCRIPTION
When build.py is invoked with --build_only, it reuses the existing controller source code to build the docker image. This assumes that the necessary sieve instrumentation for building the controller in the specified mode is already present in the source tree. But this limits passing in 'ALL' mode to build.py to build all three controller image variants at the same time. Adding in code changes to throw an error in this case until this support is added.