### PR TITLE
Add a macos platform tag in node image

### DIFF
--- a/build.py
+++ b/build.py
@@ -9,6 +9,7 @@ import os
 import stat
 import optparse
 import json
+import sys
 from sieve_common.config import (
     CommonConfig,
     load_controller_config,
@@ -532,13 +533,17 @@ def setup_controller(
 
 
 def setup_kubernetes_wrapper(version, mode, container_registry, push_to_remote):
+    platform = ""
+    # Add a platform tag when building on macOS
+    if sys.platform == "darwin":
+        platform = "macos-"
     if mode == "all":
         for this_mode in [
             sieve_modes.LEARN,
             sieve_modes.TEST,
             sieve_modes.VANILLA,
         ]:
-            image_tag = version + "-" + this_mode
+            image_tag = version + "-" + platform + this_mode
             setup_kubernetes(
                 version,
                 this_mode,
@@ -547,7 +552,7 @@ def setup_kubernetes_wrapper(version, mode, container_registry, push_to_remote):
                 push_to_remote,
             )
     else:
-        image_tag = version + "-" + mode
+        image_tag = version + "-" + platform + mode
         setup_kubernetes(version, mode, container_registry, image_tag, push_to_remote)
 
 

--- a/sieve.py
+++ b/sieve.py
@@ -11,6 +11,7 @@ from sieve_common.config import (
 import time
 import json
 import glob
+import sys
 from sieve_analyzer import analyze
 from sieve_oracle.oracle import (
     save_state,
@@ -243,9 +244,12 @@ def setup_kind_cluster(test_context: TestContext):
     kind_config = create_kind_config(
         test_context.num_apiservers, test_context.num_workers
     )
+    platform = ""
+    if sys.platform == "darwin":
+        platform = "macos-"
     k8s_container_registry = test_context.container_registry
     k8s_image_tag = (
-        test_context.controller_config.kubernetes_version + "-" + test_context.image_tag
+        test_context.controller_config.kubernetes_version + "-" + platform + test_context.image_tag
     )
     retry_cnt = 0
     # Retry cluster creation for 5 times.


### PR DESCRIPTION
Running kind on macOS with node image (that has Sieve instrumentation) built on a Linux machine is failing with errors - see https://gist.github.com/jerrinsg/578fa112c232a72360367300be563901. Building the node image locally on a Mac and using that image works though. This commit therefore adds a new "macos" platform tag to node image built for macOS so as to specifically use this image when running on Mac.