### PR TITLE
Update kind-image-build.yml

### DIFF
--- a/.github/workflows/kind-image-build.yml
+++ b/.github/workflows/kind-image-build.yml
@@ -1,16 +1,31 @@
 name: Kind Image Build
-'on':
-  workflow_dispatch: null
+on:
+  workflow_dispatch:
+    inputs:
+      platform-os:
+        description: 'The platform to build the image on'
+        default: 'ubuntu-latest'
+        required: false
+        type: choice
+        options:
+          - 'ubuntu-latest'
+          - 'macos-latest'
   # schedule:
   #   - cron: '0 5 * * *'
 env:
   IMAGE_NAMESPACE: ghcr.io/sieve-project/action
 jobs:
   build:
-    runs-on: ubuntu-latest
-    env:
-      GOPATH: /home/runner/go
+    runs-on: ${{ inputs.platform-os }}
+
     steps:
+      - name: Set up environment variables
+        run: |
+             if [ "$RUNNER_OS" == "Linux" ]; then
+               echo "GOPATH=/home/runner/go" >> "$GITHUB_ENV"
+             else
+               echo "GOPATH=/Users/runner/go" >> "$GITHUB_ENV"
+             fi
       - uses: actions/checkout@v2
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
@@ -20,6 +35,15 @@ jobs:
         uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.7
+      - name: Setup docker (missing in macOS)
+        if: runner.os == 'macos'
+        uses: docker-practice/actions-setup-docker@master
+        timeout-minutes: 12
+      - name: Install missing tools in macOS
+        if: runner.os == 'macos'
+        run: |
+              brew install bash kind
+              `brew --prefix bash`/bin/bash # building k8s in macOS needs newer bash version
       - name: Setup GitHub Package Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Install Python Packages


### PR DESCRIPTION
Adding an optional input to specify the runner on which to build the kind node image. Supported options are 'ubuntu-latest' and 'macos-latest'. Building on macOS requires installing kind and upgrading the bash version from 3.2 to the latest (5.2).